### PR TITLE
link libmilenage during building for architectures 

### DIFF
--- a/build.mak.in
+++ b/build.mak.in
@@ -26,7 +26,13 @@ endif
 # Determine which party libraries to use
 export APP_THIRD_PARTY_EXT :=
 export APP_THIRD_PARTY_LIBS :=
-export APP_THIRD_PARTY_LIB_FILES :=
+export APP_THIRD_PARTY_LIB_FILES := $(PJ_DIR)/third_party/lib/libmilenage-$(LIB_SUFFIX)
+ifeq ($(PJ_SHARED_LIBRARIES),)
+APP_THIRD_PARTY_LIBS += -lmilenage-$(TARGET_NAME)
+else
+APP_THIRD_PARTY_LIBS += -lmilenage
+APP_THIRD_PARTY_LIB_FILES += $(PJ_DIR)/third_party/lib/libmilenage.$(SHLIB_SUFFIX).$(PJ_VERSION_MAJOR) $(PJ_DIR)/third_party/lib/libmilenage.$(SHLIB_SUFFIX)
+endif
 
 ifneq (@ac_external_srtp@,0)
 # External SRTP library

--- a/third_party/build/Makefile
+++ b/third_party/build/Makefile
@@ -1,4 +1,4 @@
-DIRS =
+DIRS = milenage
 
 include ../../build.mak
 include $(PJDIR)/build/common.mak


### PR DESCRIPTION
is needed to enable PJSIP_HAS_DIGEST_AKA_AUTH, changes for AKA